### PR TITLE
Example of Enum-shift resistant config

### DIFF
--- a/ChatLogger.cs
+++ b/ChatLogger.cs
@@ -38,8 +38,7 @@ namespace ChatExtended
         {
             foreach (var log in _logConfigs)
             {
-
-                if (log.Channels[Array.IndexOf(log.ChannelEnums, type)])
+                if (log.Channels.GetValueOrDefault(type, false))
                 {
                     var file = @$"{log.Name}.txt";
 
@@ -249,9 +248,12 @@ namespace ChatExtended
             public bool ServerName = true;
             public bool PlainText = true;
             public bool ChatType = true;
-            public bool[] Channels = new bool[Enum.GetNames((typeof(XivChatType))).Length];
-            public Array ChannelEnums = Enum.GetValues(typeof(XivChatType));
 
+            // Dictionary here to provide a lookup for enabled channels
+            // that deserialize *as enum* from the config file
+            // A hashset would technically be more efficient, but it does
+            // not serialize into the Enum values themselves, solving nothing!
+            public readonly Dictionary<XivChatType, bool> Channels = new();
         }
     }
 }

--- a/Config.cs
+++ b/Config.cs
@@ -11,8 +11,11 @@ using Dalamud.Plugin;
 using ImGuiNET;
 using System.Numerics;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using ChatExtended;
 using Dalamud.Game.Text;
+using Dalamud.Utility;
 
 namespace ChatExtended
 {
@@ -95,9 +98,27 @@ namespace ChatExtended
                             ImGui.Separator();
                             ImGui.Text("Chat Channels to save");
                             ImGui.Columns(4);
-                            for (int i = 1; i < Enum.GetNames((typeof(XivChatType))).Length; i++)
+                            
+                            // Set i to -1 so we skip None
+                            var i = -1;
+                            foreach (var type in Enum.GetValues<XivChatType>())
                             {
-                                ImGui.Checkbox(Enum.GetNames(typeof(XivChatType))[i], ref log.Channels[i]);
+                                // Skip None, but make sure to increase i
+                                i++;
+                                if (i == 0) continue;
+                                
+                                // Get the setting and label for this channel
+                                var typeSetting = log.Channels.GetValueOrDefault(type, false);
+                                var label = type.GetAttribute<XivChatTypeInfoAttribute>()?.FancyName ?? type.ToString();
+                                
+                                // This is just dumb
+                                if (type == XivChatType.CrossParty)
+                                    label = "Cross-World Party";
+                                
+                                // Draw the checkbox and update the setting if it's been changed
+                                if (ImGui.Checkbox($"{label}##{i}", ref typeSetting))
+                                    log.Channels[type] = typeSetting;
+                                
                                 if (i % 10 == 0)
                                 {
                                     ImGui.NextColumn();


### PR DESCRIPTION
Just wanted to throw this out there as an example of how to resolve the "enums in config" issue.

The old config serializes a boolean set containing whether each enum value itself is enabled. If a new chat type is added (or discovered) somewhere, the enum will change but the configuration's two arrays will not.

Since Newtonsoft serializes the keys in the dictionary I've added, it does so as the enum (rather than the int value), so when it deserializes the dictionary, it will always correspond to the enum value of the same name. If an enum name changes (not the FancyName, though) you will have to write some simple config adapting code that copies the old enum value over to the new one. But it's far better than trying to manually shift the entire boolean array and re-serializing the ChannelEnums field over again.